### PR TITLE
Convert branches into their current hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,18 +214,19 @@ function resolveRef(git, url, repoPath, ref, opts, next) {
 function afterUpdate(git, url, repoPath, ref, opts, next) {
   git.tags((_, tagSummary) => {
     git.branch((err, branchSummary) => {
-      if (refIsBranch(branchSummary, tagSummary, ref)) {
-        console.error('Branches are not supported, use semver tags or sha\'s.');
-        return;
-      }
-
       git.checkout(ref, (err) => {
         if (err) {
           console.error(err);
           return;
         }
 
-        afterCheckout(url, repoPath, ref, opts, next);
+        if (refIsBranch(branchSummary, tagSummary, ref)) {
+          git.log((_, logs) => {
+            afterCheckout(url, repoPath, logs.latest.hash, opts, next);
+          });
+        } else {
+          afterCheckout(url, repoPath, ref, opts, next);
+        }
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function ensureDependencies() {
   if (!fs.existsSync('elm-stuff')) {
     fs.mkdirSync('elm-stuff');
   }
-  
+
   if (!fs.existsSync(storagePath)) {
     fs.mkdirSync(storagePath);
   }
@@ -91,7 +91,7 @@ function buildDependencyLock(elmJson) {
   } else {
     locked = Object.assign({}, elmJson['git-dependencies']);
   }
-  
+
   return locked;
 }
 
@@ -261,7 +261,7 @@ function afterCheckout(url, repoPath, ref, opts, next) {
 
   opts['locked'][url] = ref;
   opts['handled'][url] = true;
-  
+
   const depSources = ['src']; // Can packages have source directories?
   const depGitDeps = depElmJson['git-dependencies'] || {};
 
@@ -410,7 +410,7 @@ function verifyApplicationElmJson(elmJson) {
   if (gitDepsErr !== '') {
     return gitDepsErr
   }
-  
+
   return '';
 }
 


### PR DESCRIPTION
This will allow people to specify a branch out of convenience, but when `elm-git-install` is run it will be converted into the branch's current hash so there will be no problems with reproducibility.