### PR TITLE
Allow more git urls as the source

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('upath');
 const url = require('url');
 const gitInPath = require('simple-git');
-const isGitUrl = require('is-git-url');
+const isGitCloneable = require('git-clone-able');
 const semver = require('semver');
 
 const gitRoot = gitInPath(); // git client for current working directory
@@ -37,7 +37,7 @@ function ensureDependencies() {
   if (!fs.existsSync('elm-stuff')) {
     fs.mkdirSync('elm-stuff');
   }
-  
+
   if (!fs.existsSync(storagePath)) {
     fs.mkdirSync(storagePath);
   }
@@ -63,7 +63,7 @@ function buildDependencyLock(elmJson) {
   } else {
     locked = Object.assign({}, elmJson['git-dependencies']);
   }
-  
+
   return locked;
 }
 
@@ -233,7 +233,7 @@ function afterCheckout(url, repoPath, ref, opts, next) {
 
   opts['locked'][url] = ref;
   opts['handled'][url] = true;
-  
+
   const depSources = ['src']; // Can packages have source directories?
   const depGitDeps = depElmJson['git-dependencies'] || {};
 
@@ -382,7 +382,7 @@ function verifyApplicationElmJson(elmJson) {
   if (gitDepsErr !== '') {
     return gitDepsErr
   }
-  
+
   return '';
 }
 
@@ -452,7 +452,7 @@ function checkAppGitDependenciesObject(deps, depsErr) {
   for (const key in deps) {
     const val = deps[key];
 
-    if (!isGitUrl(key)) {
+    if (!isGitCloneable(key)) {
       return depsErr;
     }
   }
@@ -486,7 +486,7 @@ function verifyPackageElmJson(elmJson) {
   }
 
   for (const key in gitDeps) {
-    if (!isGitUrl(key)) {
+    if (!isGitCloneable(key)) {
       return gitDepErr;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "ms": "2.0.0"
       }
     },
-    "is-git-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
-      "integrity": "sha1-U/aEzRQyhbUsMkS05vKCU1J69ms="
+    "git-clone-able": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/git-clone-able/-/git-clone-able-0.1.2.tgz",
+      "integrity": "sha1-E9TM7TH9yqUdtQJ7PJCovfhnvMs="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "homepage": "https://github.com/Skinney/elm-git-install#readme",
     "dependencies": {
-        "is-git-url": "^1.0.0",
+        "git-clone-able": "^0.1.2",
         "semver": "^5.5.1",
         "simple-git": "^1.96.0",
         "upath": "^1.1.2"


### PR DESCRIPTION
The `is-git-url` package does not allow Bitbucket repos. I switched it for [git-clone-able](https://www.npmjs.com/package/git-clone-able) which "tries to accept any URLs that are clone able by Git".